### PR TITLE
Fixed cookie banner popup blocking on jp ver,added usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Installation
 
 Requires Chrome/Chromium to be installed. For Chromium, you need to modify `"browser"` in `config.json` to `"chromium"`.
-
+By using webdriver it is also required that you do not use snap or flatpack as webdriver cannot find the chrome binary. 
 ```bash
 pip install -U poetry
 cd fuckBookWalker
@@ -24,11 +24,16 @@ poetry install
 ### Running
 
 ```bash
-poetry run python bookphucker <url or uuid of books>
+poetry run python bookphucker <url or UUID of books>
 ```
 
 You should see something like this.
 ![sample](./imgs/sample.png)
+
+Another example, here of batch operation on UUIDs
+```bash
+poetry run python bookphucker  a70143ab-0be7-49d8-8efc-7b7ee104a0b4 e99937dd-7c18-4cf2-8547-0230864775b4
+```
 
 ### Configuration
 
@@ -37,9 +42,19 @@ wip...
 By default, `bookphucker` will try to reuse previous `cookies`, using `--no-cache` to clear `cookies`.
 
 ## Common Issues
+runing via --no-cache
+
+and set headless to false in config.json
 
 ### Cannot log in
 
 You may encounter CAPTCHA during the login process.
 
 `bookphucker` will ask you to use non-headless mode to pass the captcha if your config sets `headless` to `true`.
+
+### cannot connect to chrome at 127.0.0.1:38865
+kill all chrome instanses/processes as the program does not properly kill forked instances when done, which might cause gridlocks.
+On linux you can do
+``` bash
+pkill chrome
+```

--- a/bookphucker/config.py
+++ b/bookphucker/config.py
@@ -30,6 +30,11 @@ class Config(BaseModel):
         options.add_argument("--high-dpi-support=1")
         options.add_argument(f"--user-agent={ua}")
         options.add_argument(f"--window-size={self.viewer_size[0]},{self.viewer_size[1]}")
+        # snap specific options to allow chromedriver to find browser
+        #options.binary_location = "/usr/bin/chromium-browser"
+        #options.add_argument("--no-sandbox")
+        #options.add_argument("--disable-dev-shm-usage")
+
         chrome_type = ChromeType.CHROMIUM if self.browser == "chromium" else ChromeType.GOOGLE
         # Install matching ChromeDriver and create a Service
         service = Service(ChromeDriverManager(chrome_type=chrome_type).install())

--- a/bookphucker/jp.py
+++ b/bookphucker/jp.py
@@ -174,8 +174,14 @@ def download_book(driver: webdriver.Chrome, cfg: Config, book_uuid: str, overwri
         )
         find_click(driver, By.CLASS_NAME, "gdpr-accept")
 
+    # reject all cookies
+    WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "onetrust-reject-all-handler")))
+    find_click(driver,By.ID, "onetrust-reject-all-handler")
+
     WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.CLASS_NAME, "t-c-read-button")))
+
+
 
     find_click(driver, By.CLASS_NAME, "t-c-read-button")
 


### PR DESCRIPTION
Before there was a issue where the line in jp.py tried to click on an element which was covered by the cookie banner, causing a crash in the browser.
This code adds code to click reject on the banner before clicking on t-c-read-button.