### PR TITLE
fix ChromeDriver version mismatch and package import

### DIFF
--- a/bookphucker/__init__.py
+++ b/bookphucker/__init__.py
@@ -1,1 +1,1 @@
-from config import Config
+from .config import Config

--- a/bookphucker/config.py
+++ b/bookphucker/config.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+import re
+import shutil
+import subprocess
 import undetected_chromedriver as uc
 import logging
 from typing import Literal
@@ -10,6 +13,26 @@ from selenium.webdriver.chrome.service import Service
 
 
 CURRENT_VERSION = Version("0.2.0")
+
+
+def _detect_browser_version(browser: Literal["chrome", "chromium"]) -> tuple[int | None, str | None]:
+    """Return (major, full) version of the installed browser, or (None, None)."""
+    candidates = {
+        "chrome": ["google-chrome-stable", "google-chrome", "chrome"],
+        "chromium": ["chromium", "chromium-browser"],
+    }[browser]
+    for name in candidates:
+        path = shutil.which(name)
+        if not path:
+            continue
+        try:
+            out = subprocess.check_output([path, "--version"], text=True, timeout=5)
+        except (subprocess.SubprocessError, OSError):
+            continue
+        m = re.search(r"(\d+)\.(\d+\.\d+\.\d+)", out)
+        if m:
+            return int(m.group(1)), f"{m.group(1)}.{m.group(2)}"
+    return None, None
 
 class Config(BaseModel):
     model_config = ConfigDict(extra="allow", validate_assignment=True)
@@ -31,14 +54,26 @@ class Config(BaseModel):
         options.add_argument(f"--user-agent={ua}")
         options.add_argument(f"--window-size={self.viewer_size[0]},{self.viewer_size[1]}")
         chrome_type = ChromeType.CHROMIUM if self.browser == "chromium" else ChromeType.GOOGLE
-        # Install matching ChromeDriver and create a Service
-        service = Service(ChromeDriverManager(chrome_type=chrome_type).install())
+        # Pin ChromeDriver to the installed browser's major version so a newer
+        # default driver (e.g. 148) does not refuse to attach to an older Chrome (e.g. 147).
+        chrome_major, chrome_full = _detect_browser_version(self.browser)
+        if chrome_full is None:
+            logging.warning(
+                "Could not detect installed %s version; ChromeDriver may mismatch.",
+                self.browser,
+            )
+        service = Service(
+            ChromeDriverManager(
+                chrome_type=chrome_type,
+                driver_version=chrome_full,
+            ).install()
+        )
         # Handle headless mode via options
         if self.headless:
             # use new headless flag for modern Chrome
             options.add_argument("--headless=new")
         # Initialize undetected_chromedriver with correct service
-        driver = uc.Chrome(options=options, service=service)
+        driver = uc.Chrome(options=options, service=service, version_main=chrome_major)
         return driver
 
     def config_logging(self):


### PR DESCRIPTION
## Summary

Two small fixes that get the tool running again on a current machine:

- **`bookphucker/__init__.py`**: change `from config import Config` to `from .config import Config`. The non-relative form only works because `python bookphucker` happens to put `bookphucker/` on `sys.path`; any normal import of the package (e.g. `import bookphucker` from outside) raises `ModuleNotFoundError`.
- **`bookphucker/config.py`**: detect the locally-installed Chrome/Chromium version via `--version` and pass it to both `ChromeDriverManager(driver_version=...)` and `uc.Chrome(version_main=...)`. Previously `ChromeDriverManager()` always pulled the *latest* driver, so when the system Chrome trailed by one major version (e.g. Chrome 147 + driver 148) startup died with:

  ```
  SessionNotCreatedException: This version of ChromeDriver only supports Chrome version 148
  Current browser version is 147.x.x.x
  ```

## Test plan

- [x] `poetry run python bookphucker <jp store URL>` no longer fails at WebDriver init on a Chrome-147 host
- [x] `python -c "from bookphucker import Config"` works from outside the package directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)