### PR TITLE
support r18.bookwalker.jp store URLs

### DIFF
--- a/bookphucker/__main__.py
+++ b/bookphucker/__main__.py
@@ -25,12 +25,13 @@ def main():
                         action="store_true")
 
     args = parser.parse_args()
-    book_uuids = list[str]()
+    book_entries: list[tuple[str, str | None]] = []  # (uuid, host_override)
     region = args.region
 
     print(f"Book UUIDs:\n\n")
 
     for book_page in args.book_pages:
+        host_override: str | None = None
         if "bookwalker" in book_page:
             if not book_page.startswith("http"):
                 book_page = "https://" + book_page
@@ -38,6 +39,10 @@ def main():
             if ".jp" in book_url.hostname:
                 if region == "auto":
                     region = "jp"
+                # Preserve subdomain (e.g. r18.bookwalker.jp) so adult-store URLs
+                # are fetched on the right host instead of redirecting to the R-18 top.
+                if book_url.hostname != "bookwalker.jp":
+                    host_override = book_url.hostname
                 book_uuid = book_url.path
                 print(f"{book_uuid}")
             elif ".com.tw" in book_url.hostname:
@@ -56,7 +61,7 @@ def main():
         else:
             book_uuid = book_page
             print(f"{book_uuid}")
-        book_uuids.append(book_uuid.strip('/')[-36:])
+        book_entries.append((book_uuid.strip('/')[-36:], host_override))
 
     match region:
         case "jp" | "auto":
@@ -125,8 +130,9 @@ def main():
                 login(driver, username, password)
 
             try:
-                for book_uuid in book_uuids:
-                    download_book(driver, cfg, book_uuid, overwrite=args.overwrite)
+                for book_uuid, host_override in book_entries:
+                    download_book(driver, cfg, book_uuid, overwrite=args.overwrite,
+                                  host=host_override)
             except TimeoutException:
                 if "ERROR998" in driver.page_source:
                     logging.error("Error 998: Must log out from another device")

--- a/bookphucker/jp.py
+++ b/bookphucker/jp.py
@@ -148,10 +148,26 @@ def go2spread(driver: webdriver.Chrome, spread: int):
     go2page(driver, page_index+1)
 
 
-def download_book(driver: webdriver.Chrome, cfg: Config, book_uuid: str, overwrite):
+def download_book(driver: webdriver.Chrome, cfg: Config, book_uuid: str, overwrite,
+                  host: str | None = None):
     logging.info("Downloading book %s", book_uuid)
-    driver.get(
-        f"https://member.{domain}/app/03/webstore/cooperation?r=de{book_uuid}%2F")
+    if host and host != domain:
+        # Adult store (r18.bookwalker.jp) etc. — cooperation only redirects to the
+        # store top, so visit the product page directly. Login cookies are scoped
+        # to .bookwalker.jp and propagate to the subdomain.
+        driver.get(f"https://{host}/de{book_uuid}/")
+    else:
+        driver.get(
+            f"https://member.{domain}/app/03/webstore/cooperation?r=de{book_uuid}%2F")
+    # R-18 sites interpose an age-confirmation form (id="confirm" → /certify/confirm/)
+    # that bounces unconfirmed visitors to the R-18 top. Submit it programmatically.
+    try:
+        WebDriverWait(driver, 2).until(
+            EC.presence_of_element_located((By.ID, "confirm")))
+        logging.info("R-18 age check detected; confirming")
+        driver.execute_script("document.getElementById('confirm').submit();")
+    except TimeoutException:
+        pass
     WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.CLASS_NAME, "t-c-product-main-data__title")))
 

--- a/bookphucker/tw.py
+++ b/bookphucker/tw.py
@@ -104,7 +104,8 @@ def go2page(driver: webdriver.Chrome, menu_name: str, page: int):
     driver.execute_script(f"{menu_name}.options.a6l.moveToPage({page-1});")
 
 
-def download_book(driver: webdriver.Chrome, cfg: Config, book_uuid: str, overwrite):
+def download_book(driver: webdriver.Chrome, cfg: Config, book_uuid: str, overwrite,
+                  host: str | None = None):
     logging.info("Downloading book %s", book_uuid)
     driver.get(
         f"https://www.bookwalker.com.tw/browserViewer/{book_uuid}/trial_end")


### PR DESCRIPTION
## Summary

Adds support for downloading from `r18.bookwalker.jp` (the adult store), which currently fails because:

1. `member.bookwalker.jp`'s cooperation endpoint redirects R-18 product URLs to the R-18 top page instead of the requested product, so the existing flow never lands on a product page.
2. Even when navigating directly, the R-18 store interposes an age-confirmation form (`<form action="/certify/confirm/" id="confirm">`) that bounces unconfirmed visitors back to the top.

Changes:

- `__main__.py`: keep the original hostname when parsing input URLs and pass it through as a `host` argument to `download_book`. For `bookwalker.jp` itself behaviour is unchanged.
- `jp.py`: when a non-default jp host is supplied, skip the cooperation redirect and visit `https://<host>/de<UUID>/` directly. Login cookies are scoped to `.bookwalker.jp` so they propagate to the subdomain. After navigation, if the age-confirmation form is present, submit it programmatically to obtain the certify cookie and reach the product page.
- `tw.py`: add the same `host` kwarg (ignored) so call sites stay uniform.

## Test plan

- [x] `poetry run python bookphucker https://r18.bookwalker.jp/de<UUID>/` reaches the product page and proceeds to the viewer
- [x] `poetry run python bookphucker https://bookwalker.jp/de<UUID>/` regular store flow unchanged (cooperation path still used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)